### PR TITLE
fix: Pdv 82 update spring cloud version to 2020.0.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <java.version>11</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <spring-cloud.version>2020.0.4</spring-cloud.version>
+        <spring-cloud.version>2020.0.6</spring-cloud.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
This PR updates Spring Cloud Version from **2020.0.4** to **2020.0.6**