### PR TITLE
feat: Spring Boot upgrade to 3.1.4

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -26,10 +26,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@1df8dbefe2a8cbc99770194893dd902763bee34b
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
       - name: Build with Maven
         run: >

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -23,14 +23,14 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       AWS_REGION: eu-south-1
-      AWS_ACCESS_KEY_ID: dummy-key
-      AWS_SECRET_KEY: dummy-secrey-key
+      AWS_ACCESS_KEY_ID: dummy
+      AWS_SECRET_KEY: dummy
     steps:
     - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
     - name: Set up JDK
       uses: actions/setup-java@1df8dbefe2a8cbc99770194893dd902763bee34b
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'temurin'
     - name: Prepare SonarCloud analysis configuration
       run: >

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk11:alpine-jre@sha256:789f551fca5e233b1593aee65283d5981b3a82284e15a8cad4c798315188f848
+FROM eclipse-temurin:17-jre-alpine@sha256:839f3208bfc22f17bf57391d5c91d51c627d032d6900a0475228b94e48a8f9b3
 VOLUME /tmp
 COPY target/*.jar app.jar
 ENTRYPOINT ["java","-jar","app.jar"]

--- a/app/src/main/resources/config/application.yml
+++ b/app/src/main/resources/config/application.yml
@@ -17,9 +17,6 @@ spring:
       - swaggerEN
   zipkin:
     enabled: false
-  sleuth:
-    propagation:
-      type: AWS
 
 info:
   build:
@@ -32,6 +29,10 @@ springdoc:
   api-docs:
     resolve-schema-properties: true
   writer-with-order-by-keys: true
+
+management:
+  sampling:
+    probability: 1.0
 
 logging:
   level:

--- a/app/src/main/resources/config/application.yml
+++ b/app/src/main/resources/config/application.yml
@@ -31,6 +31,13 @@ springdoc:
   writer-with-order-by-keys: true
 
 management:
+  tracing:
+    baggage:
+      correlation:
+        fields:
+          - x-amzn-trace-id
+      remote-fields:
+        - x-amzn-trace-id
   sampling:
     probability: 1.0
 

--- a/app/src/main/resources/config/application.yml
+++ b/app/src/main/resources/config/application.yml
@@ -15,8 +15,6 @@ spring:
     include:
       # TO enable specific-language documentations
       - swaggerEN
-  zipkin:
-    enabled: false
 
 info:
   build:
@@ -38,8 +36,6 @@ management:
           - x-amzn-trace-id
       remote-fields:
         - x-amzn-trace-id
-  sampling:
-    probability: 1.0
 
 logging:
   level:

--- a/connector-api/src/test/java/it/pagopa/pdv/user_registry/TestUtils.java
+++ b/connector-api/src/test/java/it/pagopa/pdv/user_registry/TestUtils.java
@@ -1,13 +1,13 @@
 package it.pagopa.pdv.user_registry;
 
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
 import lombok.Value;
 import org.junit.jupiter.api.Assertions;
 import org.springframework.util.StringUtils;
 
-import javax.validation.ConstraintViolation;
-import javax.validation.Validation;
-import javax.validation.Validator;
-import javax.validation.ValidatorFactory;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;

--- a/connector/rest/pom.xml
+++ b/connector/rest/pom.xml
@@ -26,13 +26,19 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.github.openfeign</groupId>
             <artifactId>feign-httpclient</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/connector/rest/src/main/java/it/pagopa/pdv/user_registry/connector/rest/config/RestClientBaseConfig.java
+++ b/connector/rest/src/main/java/it/pagopa/pdv/user_registry/connector/rest/config/RestClientBaseConfig.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import feign.RequestInterceptor;
 import feign.codec.Decoder;
 import feign.codec.Encoder;
+import feign.okhttp.OkHttpClient;
 import it.pagopa.pdv.user_registry.connector.rest.interceptor.QueryParamsPlusEncoderInterceptor;
 import org.springframework.beans.factory.ObjectFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -46,5 +47,14 @@ public class RestClientBaseConfig {
 
         return new SpringEncoder(objectFactory);
     }
+
+    @Configuration
+    public class FeignConfiguration {
+        @Bean
+        public OkHttpClient client() {
+            return new OkHttpClient();
+        }
+    }
+
 
 }

--- a/connector/rest/src/test/java/it/pagopa/pdv/user_registry/connector/rest/client/PersonRestClientTest.java
+++ b/connector/rest/src/test/java/it/pagopa/pdv/user_registry/connector/rest/client/PersonRestClientTest.java
@@ -20,7 +20,6 @@ import org.junit.jupiter.api.function.Executable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.http.HttpMessageConvertersAutoConfiguration;
 import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.cloud.commons.httpclient.HttpClientConfiguration;
 import org.springframework.cloud.openfeign.FeignAutoConfiguration;
 import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -41,8 +40,7 @@ import static org.junit.jupiter.api.Assertions.*;
                 PersonRestClientTest.Config.class,
                 PersonRestClientTestConfig.class,
                 FeignAutoConfiguration.class,
-                HttpMessageConvertersAutoConfiguration.class,
-                HttpClientConfiguration.class})
+                HttpMessageConvertersAutoConfiguration.class})
 @TestPropertySource(
         properties = {
                 "logging.level.it.pagopa.pdv.user_registry.connector.rest=DEBUG",

--- a/connector/rest/src/test/java/it/pagopa/pdv/user_registry/connector/rest/client/TokenizerRestClientTest.java
+++ b/connector/rest/src/test/java/it/pagopa/pdv/user_registry/connector/rest/client/TokenizerRestClientTest.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.http.HttpMessageConvertersAutoConfiguration;
 import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.cloud.commons.httpclient.HttpClientConfiguration;
 import org.springframework.cloud.openfeign.FeignAutoConfiguration;
 import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -43,8 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
                 TokenizerRestClientTest.Config.class,
                 TokenizerRestClientTestConfig.class,
                 FeignAutoConfiguration.class,
-                HttpMessageConvertersAutoConfiguration.class,
-                HttpClientConfiguration.class})
+                HttpMessageConvertersAutoConfiguration.class})
 @TestPropertySource(
         properties = {
                 "logging.level.it.pagopa.pdv.user_registry.connector.rest=DEBUG",

--- a/core/src/main/resources/logback-spring.xml
+++ b/core/src/main/resources/logback-spring.xml
@@ -39,7 +39,7 @@
                 </else>
             </if>
             <property name="stdout_log_pattern"
-                      value="%clr(%d{${LOG_DATEFORMAT_PATTERN}}){faint} %clr(%5p) [${appName:-},%X{traceId:-},%X{spanId:-}] %clr(${PID:- }){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} ${msg_and_ex_log_pattern}"/>
+                      value="%clr(%d{${LOG_DATEFORMAT_PATTERN}}){faint} %clr(%5p) [${appName:-},%X{traceId:-},%X{spanId:-},%X{x-amzn-trace-id:-}] %clr(${PID:- }){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} ${msg_and_ex_log_pattern}"/>
             <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
                 <encoder>
                     <pattern>${stdout_log_pattern}</pattern>

--- a/pom.xml
+++ b/pom.xml
@@ -122,10 +122,6 @@
             <artifactId>micrometer-tracing-bridge-brave</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.zipkin.reporter2</groupId>
-            <artifactId>zipkin-reporter-brave</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.github.loki4j</groupId>
             <artifactId>loki-logback-appender</artifactId>
             <version>1.4.2</version>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.13</version>
+        <version>3.1.4</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <artifactId>pdv-ms-user-registry</artifactId>
@@ -16,10 +16,10 @@
     <description>Microservice to manage person entity</description>
 
     <properties>
-        <java.version>11</java.version>
+        <java.version>17</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <spring-cloud.version>2021.0.8</spring-cloud.version>
+        <spring-cloud.version>2022.0.3</spring-cloud.version>
     </properties>
 
     <dependencyManagement>
@@ -28,6 +28,13 @@
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-dependencies</artifactId>
                 <version>${spring-cloud.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.micrometer</groupId>
+                <artifactId>micrometer-tracing-bom</artifactId>
+                <version>${micrometer-tracing.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -65,8 +72,8 @@
             </dependency>
             <dependency>
                 <groupId>org.springdoc</groupId>
-                <artifactId>springdoc-openapi-ui</artifactId>
-                <version>1.7.0</version>
+                <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+                <version>2.2.0</version>
             </dependency>
             <dependency>
                 <groupId>ch.qos.logback.contrib</groupId>
@@ -112,15 +119,40 @@
         </dependency>
         <dependency>
             <groupId>io.micrometer</groupId>
-            <artifactId>micrometer-registry-prometheus</artifactId>
+            <artifactId>micrometer-tracing-bridge-brave</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.zipkin.reporter2</groupId>
+            <artifactId>zipkin-reporter-brave</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.loki4j</groupId>
+            <artifactId>loki-logback-appender</artifactId>
+            <version>1.4.2</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.openfeign</groupId>
+            <artifactId>feign-okhttp</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.github.openfeign</groupId>
+            <artifactId>feign-micrometer</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.codehaus.janino</groupId>
             <artifactId>janino</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-sleuth</artifactId>
         </dependency>
     </dependencies>
 

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -21,7 +21,7 @@
         </dependency>
         <dependency>
             <groupId>org.springdoc</groupId>
-            <artifactId>springdoc-openapi-ui</artifactId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>

--- a/web/src/main/java/it/pagopa/pdv/user_registry/web/config/WebConfig.java
+++ b/web/src/main/java/it/pagopa/pdv/user_registry/web/config/WebConfig.java
@@ -13,6 +13,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.PathMatchConfigurer;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import java.util.Collection;
@@ -38,6 +39,10 @@ class WebConfig implements WebMvcConfigurer {
         if (interceptors != null) {
             interceptors.forEach(registry::addInterceptor);
         }
+    }
+    @Override
+    public void configurePathMatch(PathMatchConfigurer configurer) {
+        configurer.setUseTrailingSlashMatch(true);
     }
 
 

--- a/web/src/main/java/it/pagopa/pdv/user_registry/web/controller/UserController.java
+++ b/web/src/main/java/it/pagopa/pdv/user_registry/web/controller/UserController.java
@@ -12,13 +12,13 @@ import it.pagopa.pdv.user_registry.core.model.User;
 import it.pagopa.pdv.user_registry.web.annotations.CommonApiResponsesWrapper;
 import it.pagopa.pdv.user_registry.web.model.*;
 import it.pagopa.pdv.user_registry.web.model.mapper.UserMapper;
+import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 
-import javax.validation.Valid;
 import java.util.EnumSet;
 import java.util.UUID;
 

--- a/web/src/main/java/it/pagopa/pdv/user_registry/web/filters/BaggageFieldFilter.java
+++ b/web/src/main/java/it/pagopa/pdv/user_registry/web/filters/BaggageFieldFilter.java
@@ -1,0 +1,43 @@
+package it.pagopa.pdv.user_registry.web.filters;
+
+import io.micrometer.tracing.Tracer;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+
+@Slf4j
+@Component
+public class BaggageFieldFilter extends OncePerRequestFilter {
+    private Tracer tracer;
+
+    private static final String field = "x-amzn-trace-id";
+
+    private static final String BAGGAGE_SETTING_EXCEPTION = "Exception during baggage field setting";
+
+    BaggageFieldFilter(Tracer tracer) {
+        this.tracer = tracer;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws IOException, ServletException {
+        try {
+            String rawBaggage = tracer.getBaggage(field).get();
+            if (rawBaggage != null) {
+                tracer.createBaggage(field, rawBaggage.replaceAll("=", ":"));
+            }
+        }
+        catch (Exception e) {
+            log.error(BAGGAGE_SETTING_EXCEPTION, e.getMessage());
+        }
+
+        filterChain.doFilter(request, response);
+
+    }
+}

--- a/web/src/main/java/it/pagopa/pdv/user_registry/web/handler/RestExceptionsHandler.java
+++ b/web/src/main/java/it/pagopa/pdv/user_registry/web/handler/RestExceptionsHandler.java
@@ -3,6 +3,8 @@ package it.pagopa.pdv.user_registry.web.handler;
 import feign.FeignException;
 import it.pagopa.pdv.user_registry.web.model.Problem;
 import it.pagopa.pdv.user_registry.web.model.mapper.ProblemMapper;
+import jakarta.servlet.ServletException;
+import jakarta.validation.ValidationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -16,8 +18,6 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
-import javax.servlet.ServletException;
-import javax.validation.ValidationException;
 import java.util.Optional;
 import java.util.stream.Collectors;
 

--- a/web/src/main/java/it/pagopa/pdv/user_registry/web/interceptor/LogRequestInterceptor.java
+++ b/web/src/main/java/it/pagopa/pdv/user_registry/web/interceptor/LogRequestInterceptor.java
@@ -1,11 +1,11 @@
 package it.pagopa.pdv.user_registry.web.interceptor;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import java.util.Collection;
 import java.util.List;
 

--- a/web/src/main/java/it/pagopa/pdv/user_registry/web/model/CertifiableFieldResource.java
+++ b/web/src/main/java/it/pagopa/pdv/user_registry/web/model/CertifiableFieldResource.java
@@ -1,10 +1,9 @@
 package it.pagopa.pdv.user_registry.web.model;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
-import javax.validation.constraints.NotNull;
 
 @Data
 @NoArgsConstructor

--- a/web/src/main/java/it/pagopa/pdv/user_registry/web/model/MutableUserFieldsDto.java
+++ b/web/src/main/java/it/pagopa/pdv/user_registry/web/model/MutableUserFieldsDto.java
@@ -1,9 +1,9 @@
 package it.pagopa.pdv.user_registry.web.model;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import lombok.Data;
 
-import javax.validation.Valid;
 import java.time.LocalDate;
 import java.util.Map;
 

--- a/web/src/main/java/it/pagopa/pdv/user_registry/web/model/Problem.java
+++ b/web/src/main/java/it/pagopa/pdv/user_registry/web/model/Problem.java
@@ -2,6 +2,9 @@ package it.pagopa.pdv.user_registry.web.model;
 
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -10,9 +13,6 @@ import org.springframework.web.context.request.RequestAttributes;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
-import javax.validation.constraints.Max;
-import javax.validation.constraints.Min;
-import javax.validation.constraints.NotBlank;
 import java.io.Serializable;
 import java.util.List;
 

--- a/web/src/main/java/it/pagopa/pdv/user_registry/web/model/SaveUserDto.java
+++ b/web/src/main/java/it/pagopa/pdv/user_registry/web/model/SaveUserDto.java
@@ -3,9 +3,8 @@ package it.pagopa.pdv.user_registry.web.model;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.swagger.v3.oas.annotations.media.Schema;
 import it.pagopa.pdv.user_registry.web.converter.UpperCaseConverter;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
-
-import javax.validation.constraints.NotBlank;
 
 @Data
 public class SaveUserDto extends MutableUserFieldsDto {

--- a/web/src/main/java/it/pagopa/pdv/user_registry/web/model/UserId.java
+++ b/web/src/main/java/it/pagopa/pdv/user_registry/web/model/UserId.java
@@ -1,9 +1,9 @@
 package it.pagopa.pdv.user_registry.web.model;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
-import javax.validation.constraints.NotNull;
 import java.util.UUID;
 
 @Data

--- a/web/src/main/java/it/pagopa/pdv/user_registry/web/model/UserResource.java
+++ b/web/src/main/java/it/pagopa/pdv/user_registry/web/model/UserResource.java
@@ -1,11 +1,11 @@
 package it.pagopa.pdv.user_registry.web.model;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.experimental.FieldNameConstants;
 
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
 import java.time.LocalDate;
 import java.util.Map;
 import java.util.UUID;

--- a/web/src/main/java/it/pagopa/pdv/user_registry/web/model/UserSearchDto.java
+++ b/web/src/main/java/it/pagopa/pdv/user_registry/web/model/UserSearchDto.java
@@ -3,9 +3,8 @@ package it.pagopa.pdv.user_registry.web.model;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.swagger.v3.oas.annotations.media.Schema;
 import it.pagopa.pdv.user_registry.web.converter.UpperCaseConverter;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
-
-import javax.validation.constraints.NotBlank;
 
 @Data
 public class UserSearchDto {

--- a/web/src/main/java/it/pagopa/pdv/user_registry/web/model/WorkContactResource.java
+++ b/web/src/main/java/it/pagopa/pdv/user_registry/web/model/WorkContactResource.java
@@ -1,9 +1,8 @@
 package it.pagopa.pdv.user_registry.web.model;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import lombok.Data;
-
-import javax.validation.Valid;
 
 @Data
 public class WorkContactResource {

--- a/web/src/main/java/it/pagopa/pdv/user_registry/web/validator/UserControllerResponseValidator.java
+++ b/web/src/main/java/it/pagopa/pdv/user_registry/web/validator/UserControllerResponseValidator.java
@@ -1,6 +1,8 @@
 package it.pagopa.pdv.user_registry.web.validator;
 
 import it.pagopa.pdv.user_registry.web.exception.ResponseValidationException;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validator;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.AfterReturning;
@@ -9,8 +11,6 @@ import org.aspectj.lang.annotation.Pointcut;
 import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
 
-import javax.validation.ConstraintViolation;
-import javax.validation.Validator;
 import java.util.*;
 
 @Slf4j

--- a/web/src/test/java/it/pagopa/pdv/user_registry/web/controller/DummyModel.java
+++ b/web/src/test/java/it/pagopa/pdv/user_registry/web/controller/DummyModel.java
@@ -1,9 +1,8 @@
 package it.pagopa.pdv.user_registry.web.controller;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
-
-import javax.validation.constraints.NotNull;
 
 @NoArgsConstructor
 @AllArgsConstructor

--- a/web/src/test/java/it/pagopa/pdv/user_registry/web/filters/BaggageFieldFilterTest.java
+++ b/web/src/test/java/it/pagopa/pdv/user_registry/web/filters/BaggageFieldFilterTest.java
@@ -1,0 +1,53 @@
+package it.pagopa.pdv.user_registry.web.filters;
+
+import io.micrometer.tracing.Baggage;
+import io.micrometer.tracing.Tracer;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+
+public class BaggageFieldFilterTest {
+
+    @Test
+    void doFilterInternal_withBaggage() {
+        //given
+        Tracer tracer = Mockito.mock(Tracer.class);
+        Baggage baggage = Mockito.mock(Baggage.class);
+        Mockito.when(tracer.getBaggage("x-amzn-trace-id")).thenReturn(baggage);
+        Mockito.when(baggage.get()).thenReturn("test");
+        BaggageFieldFilter baggageFieldFilter = new BaggageFieldFilter(tracer);
+
+        MockFilterChain mockChain = new MockFilterChain();
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        MockHttpServletResponse rsp = new MockHttpServletResponse();
+
+        //then
+
+        assertDoesNotThrow(() -> baggageFieldFilter.doFilter(req, rsp, mockChain));
+
+    }
+
+    @Test
+    void doFilterInternal_withoutBaggage(){
+        //given
+        Tracer tracer = Mockito.mock(Tracer.class);
+        Baggage baggage = Mockito.mock(Baggage.class);
+        Mockito.when(tracer.getBaggage("x-amzn-trace-id")).thenReturn(baggage);
+        Mockito.when(baggage.get()).thenReturn(null);
+        BaggageFieldFilter baggageFieldFilter = new BaggageFieldFilter(tracer);
+
+        MockFilterChain mockChain = new MockFilterChain();
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        MockHttpServletResponse rsp = new MockHttpServletResponse();
+
+        //then
+
+        assertDoesNotThrow(() -> baggageFieldFilter.doFilter(req, rsp, mockChain));
+
+    }
+}

--- a/web/src/test/java/it/pagopa/pdv/user_registry/web/handler/RestExceptionsHandlerTest.java
+++ b/web/src/test/java/it/pagopa/pdv/user_registry/web/handler/RestExceptionsHandlerTest.java
@@ -2,6 +2,8 @@ package it.pagopa.pdv.user_registry.web.handler;
 
 import feign.FeignException;
 import it.pagopa.pdv.user_registry.web.model.Problem;
+import jakarta.servlet.ServletException;
+import jakarta.validation.ValidationException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -18,8 +20,6 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
-import javax.servlet.ServletException;
-import javax.validation.ValidationException;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/web/src/test/java/it/pagopa/pdv/user_registry/web/model/CertifiableFieldResourceTest.java
+++ b/web/src/test/java/it/pagopa/pdv/user_registry/web/model/CertifiableFieldResourceTest.java
@@ -1,13 +1,13 @@
 package it.pagopa.pdv.user_registry.web.model;
 
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import jakarta.validation.constraints.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import javax.validation.ConstraintViolation;
-import javax.validation.Validation;
-import javax.validation.Validator;
-import javax.validation.ValidatorFactory;
-import javax.validation.constraints.NotNull;
 import java.lang.annotation.Annotation;
 import java.util.HashMap;
 import java.util.List;

--- a/web/src/test/java/it/pagopa/pdv/user_registry/web/model/SaveUserDtoTest.java
+++ b/web/src/test/java/it/pagopa/pdv/user_registry/web/model/SaveUserDtoTest.java
@@ -1,13 +1,13 @@
 package it.pagopa.pdv.user_registry.web.model;
 
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import jakarta.validation.constraints.NotBlank;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import javax.validation.ConstraintViolation;
-import javax.validation.Validation;
-import javax.validation.Validator;
-import javax.validation.ValidatorFactory;
-import javax.validation.constraints.NotBlank;
 import java.lang.annotation.Annotation;
 import java.util.HashMap;
 import java.util.List;

--- a/web/src/test/java/it/pagopa/pdv/user_registry/web/model/UserIdTest.java
+++ b/web/src/test/java/it/pagopa/pdv/user_registry/web/model/UserIdTest.java
@@ -1,14 +1,14 @@
 package it.pagopa.pdv.user_registry.web.model;
 
 import it.pagopa.pdv.user_registry.TestUtils;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import jakarta.validation.constraints.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import javax.validation.ConstraintViolation;
-import javax.validation.Validation;
-import javax.validation.Validator;
-import javax.validation.ValidatorFactory;
-import javax.validation.constraints.NotNull;
 import java.lang.annotation.Annotation;
 import java.util.HashMap;
 import java.util.List;

--- a/web/src/test/java/it/pagopa/pdv/user_registry/web/model/UserResourceTest.java
+++ b/web/src/test/java/it/pagopa/pdv/user_registry/web/model/UserResourceTest.java
@@ -1,14 +1,14 @@
 package it.pagopa.pdv.user_registry.web.model;
 
 import it.pagopa.pdv.user_registry.TestUtils;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import jakarta.validation.constraints.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import javax.validation.ConstraintViolation;
-import javax.validation.Validation;
-import javax.validation.Validator;
-import javax.validation.ValidatorFactory;
-import javax.validation.constraints.NotNull;
 import java.lang.annotation.Annotation;
 import java.util.HashMap;
 import java.util.List;

--- a/web/src/test/java/it/pagopa/pdv/user_registry/web/model/UserSearchDtoTest.java
+++ b/web/src/test/java/it/pagopa/pdv/user_registry/web/model/UserSearchDtoTest.java
@@ -1,14 +1,14 @@
 package it.pagopa.pdv.user_registry.web.model;
 
 import it.pagopa.pdv.user_registry.TestUtils;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import jakarta.validation.constraints.NotBlank;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import javax.validation.ConstraintViolation;
-import javax.validation.Validation;
-import javax.validation.Validator;
-import javax.validation.ValidatorFactory;
-import javax.validation.constraints.NotBlank;
 import java.lang.annotation.Annotation;
 import java.util.HashMap;
 import java.util.List;


### PR DESCRIPTION
This **PR** introduces Spring Boot upgrade from `2.7.13` to **`3.1.4`**.
Some of the most important changes are:
- `JDK` version upgrade from `11` to `17` with subsequently change from `javax` packages to `jakarta`
- `spring-cloud` version upgrade from `2021.0.8` to `2022.0.3` due to Spring Boot upgrade.
- Tracing library migration from `spring-cloud-sleuth` to `micrometer-tracing` due to Spring Boot upgrade.
- New _trace id_ correlation mode with a standard `traceId` propagation (W3C format) plus a custom-field (_baggage_) populated with `x-amzn-trace-id`. A new `OncePerRequestFilter` is added to manage this field.
- Minor code refactoring related to overall framework upgrade.
