### PR TITLE
ci: Change build-and-deploy pipeline trigger to meet Release step requirement

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -4,14 +4,6 @@ on:
   push:
     branches:
       - "**"
-      - "!main"
-      - "!develop"
-  pull_request:
-    types:
-      - closed
-    branches:
-      - "main"
-      - "develop"
     paths:
       - "**/src/main/**"
       - "**pom.xml"
@@ -49,9 +41,9 @@ jobs:
       - name: Set Dynamic Env Matrix
         id: setmatrix
         run: |
-          if [ ${{ github.event.pull_request.base.ref == 'main' }} == true ]; then 
+          if [ ${{ github.ref	 == 'refs/heads/main' }} == true ]; then 
             matrixStringifiedObject="{\"include\":[{\"environment\": \"prod\", \"env_short\": \"p\"},{\"environment\": \"uat\", \"env_short\": \"u\"}]}"
-          elif [ ${{ github.event.pull_request.base.ref == 'develop' }} == true ]; then
+          elif [ ${{ github.ref	 == 'refs/heads/develop' }} == true ]; then
             matrixStringifiedObject="{\"include\":[{\"environment\": \"dev\", \"env_short\": \"d\"}]}"
           else
             matrixStringifiedObject=""


### PR DESCRIPTION
In this pr the pipeline has been modified in order to trigger the deploy on push instead of on merge.
This change affects the release, so after a push on main a new release is created.