### PR TITLE
feat: Add AWS ECS plugin for AWS X-Ray tracing and enable tracing on ApacheHttpClient

### DIFF
--- a/app/src/main/resources/config/application.yml
+++ b/app/src/main/resources/config/application.yml
@@ -28,15 +28,6 @@ springdoc:
     resolve-schema-properties: true
   writer-with-order-by-keys: true
 
-management:
-  tracing:
-    baggage:
-      correlation:
-        fields:
-          - x-amzn-trace-id
-      remote-fields:
-        - x-amzn-trace-id
-
 logging:
   level:
     it.pagopa.pdv.user_registry: ${APP_LOG_LEVEL:DEBUG}

--- a/connector/rest/pom.xml
+++ b/connector/rest/pom.xml
@@ -50,6 +50,56 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-xray-recorder-sdk-core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-xray-recorder-sdk-apache-http</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-xray-recorder-sdk-aws-sdk</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-xray-recorder-sdk-aws-sdk-v2</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-xray-recorder-sdk-aws-sdk-instrumentor</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
 </project>

--- a/connector/rest/src/main/java/it/pagopa/pdv/user_registry/connector/rest/config/RestClientBaseConfig.java
+++ b/connector/rest/src/main/java/it/pagopa/pdv/user_registry/connector/rest/config/RestClientBaseConfig.java
@@ -1,14 +1,20 @@
 package it.pagopa.pdv.user_registry.connector.rest.config;
 
+import com.amazonaws.xray.proxies.apache.http.HttpClientBuilder;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import feign.Client;
 import feign.RequestInterceptor;
 import feign.codec.Decoder;
 import feign.codec.Encoder;
-import feign.okhttp.OkHttpClient;
+import feign.httpclient.ApacheHttpClient;
 import it.pagopa.pdv.user_registry.connector.rest.interceptor.QueryParamsPlusEncoderInterceptor;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.springframework.beans.factory.ObjectFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.http.HttpMessageConverters;
+import org.springframework.cloud.openfeign.support.FeignHttpClientProperties;
 import org.springframework.cloud.openfeign.support.ResponseEntityDecoder;
 import org.springframework.cloud.openfeign.support.SpringDecoder;
 import org.springframework.cloud.openfeign.support.SpringEncoder;
@@ -24,6 +30,11 @@ public class RestClientBaseConfig {
     @Autowired
     private ObjectMapper objectMapper;
 
+    @Value("${feign.client.config.default.connectTimeout}")
+    private int connectTimeout;
+
+    @Value("${feign.client.config.default.readTimeout}")
+    private int readTimeout;
 
     @Bean
     public RequestInterceptor queryParamsPlusEncoderInterceptor() {
@@ -47,11 +58,36 @@ public class RestClientBaseConfig {
 
         return new SpringEncoder(objectFactory);
     }
+    @Bean
+    public HttpClientBuilder xrayHttpClientBuilder() {
+
+        return HttpClientBuilder.create();
+    }
     @Configuration
     public class FeignConfiguration {
         @Bean
-        public OkHttpClient client() {
-            return new OkHttpClient();
+        public Client client(HttpClientBuilder httpClientBuilder, FeignHttpClientProperties httpClientProperties) {
+
+            httpClientBuilder = httpClientBuilder != null ? httpClientBuilder : HttpClientBuilder.create();
+
+            final PoolingHttpClientConnectionManager poolingHttpClientConnectionManager =
+                    new PoolingHttpClientConnectionManager();
+            poolingHttpClientConnectionManager.setDefaultMaxPerRoute(200);
+            poolingHttpClientConnectionManager.setMaxTotal(200);
+
+            final RequestConfig defaultRequestConfig = RequestConfig.custom()
+                    .setConnectionRequestTimeout(connectTimeout)
+                    .setConnectTimeout(httpClientProperties.getConnectionTimeout())
+                    .setSocketTimeout(readTimeout)
+                    .setRedirectsEnabled(httpClientProperties.isFollowRedirects())
+                    .build();
+
+            return new ApacheHttpClient(
+                    httpClientBuilder
+                            .setConnectionManager(poolingHttpClientConnectionManager)
+                            .setDefaultRequestConfig(defaultRequestConfig)
+                            .build()
+            );
         }
     }
 

--- a/connector/rest/src/main/java/it/pagopa/pdv/user_registry/connector/rest/config/RestClientBaseConfig.java
+++ b/connector/rest/src/main/java/it/pagopa/pdv/user_registry/connector/rest/config/RestClientBaseConfig.java
@@ -47,7 +47,6 @@ public class RestClientBaseConfig {
 
         return new SpringEncoder(objectFactory);
     }
-
     @Configuration
     public class FeignConfiguration {
         @Bean

--- a/core/src/main/resources/logback-spring.xml
+++ b/core/src/main/resources/logback-spring.xml
@@ -39,7 +39,7 @@
                 </else>
             </if>
             <property name="stdout_log_pattern"
-                      value="%clr(%d{${LOG_DATEFORMAT_PATTERN}}){faint} %clr(%5p) [${appName:-},%X{traceId:-},%X{spanId:-},%X{x-amzn-trace-id:-}] %clr(${PID:- }){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} ${msg_and_ex_log_pattern}"/>
+                      value="%clr(%d{${LOG_DATEFORMAT_PATTERN}}){faint} %clr(%5p) [${appName:-},%X{traceId:-},%X{spanId:-},%X{AWS-XRAY-TRACE-ID:-}] %clr(${PID:- }){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} ${msg_and_ex_log_pattern}"/>
             <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
                 <encoder>
                     <pattern>${stdout_log_pattern}</pattern>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -50,6 +50,10 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-xray-recorder-sdk-slf4j</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/web/src/main/java/it/pagopa/pdv/user_registry/web/config/WebConfig.java
+++ b/web/src/main/java/it/pagopa/pdv/user_registry/web/config/WebConfig.java
@@ -5,6 +5,7 @@ import com.amazonaws.xray.AWSXRayRecorderBuilder;
 import com.amazonaws.xray.jakarta.servlet.AWSXRayServletFilter;
 import com.amazonaws.xray.plugins.EC2Plugin;
 import com.amazonaws.xray.plugins.ECSPlugin;
+import com.amazonaws.xray.slf4j.SLF4JSegmentListener;
 import com.amazonaws.xray.strategy.jakarta.SegmentNamingStrategy;
 import com.amazonaws.xray.strategy.sampling.CentralizedSamplingStrategy;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
@@ -58,8 +59,14 @@ class WebConfig implements WebMvcConfigurer {
     }
 
     static {
-        AWSXRayRecorderBuilder builder = AWSXRayRecorderBuilder.standard().withPlugin(new ECSPlugin()).withPlugin(new EC2Plugin());
+        AWSXRayRecorderBuilder builder = AWSXRayRecorderBuilder
+                .standard()
+                .withSegmentListener(new SLF4JSegmentListener(""))
+                .withPlugin(new ECSPlugin())
+                .withPlugin(new EC2Plugin());
+
         builder.withSamplingStrategy(new CentralizedSamplingStrategy());
+
         AWSXRay.setGlobalRecorder(builder.build());
     }
     @Bean

--- a/web/src/main/java/it/pagopa/pdv/user_registry/web/config/WebConfig.java
+++ b/web/src/main/java/it/pagopa/pdv/user_registry/web/config/WebConfig.java
@@ -1,7 +1,12 @@
 package it.pagopa.pdv.user_registry.web.config;
 
+import com.amazonaws.xray.AWSXRay;
+import com.amazonaws.xray.AWSXRayRecorderBuilder;
 import com.amazonaws.xray.jakarta.servlet.AWSXRayServletFilter;
+import com.amazonaws.xray.plugins.EC2Plugin;
+import com.amazonaws.xray.plugins.ECSPlugin;
 import com.amazonaws.xray.strategy.jakarta.SegmentNamingStrategy;
+import com.amazonaws.xray.strategy.sampling.CentralizedSamplingStrategy;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
@@ -52,11 +57,15 @@ class WebConfig implements WebMvcConfigurer {
         configurer.setUseTrailingSlashMatch(true);
     }
 
+    static {
+        AWSXRayRecorderBuilder builder = AWSXRayRecorderBuilder.standard().withPlugin(new ECSPlugin()).withPlugin(new EC2Plugin());
+        builder.withSamplingStrategy(new CentralizedSamplingStrategy());
+        AWSXRay.setGlobalRecorder(builder.build());
+    }
     @Bean
     public Filter TracingFilter() {
         return new AWSXRayServletFilter(SegmentNamingStrategy.dynamic(this.applicationContext.getId()));
     }
-
     //    @Bean
 //    @Primary
     public ObjectMapper objectMapper() {


### PR DESCRIPTION
This PR introduces AWS X-Ray ECS plugin and tracing over ApacheHttpClient in order to enrich informations regarding X-Ray Service Map.

Minor changes includes the removal of baggage field `x-amzn-trace-id `via header propagation which is now directly obtained via AWS X-Ray sdk.